### PR TITLE
feat: bundle less languages with the Monaco editor

### DIFF
--- a/frontend/src/components/editor.tsx
+++ b/frontend/src/components/editor.tsx
@@ -3,20 +3,12 @@ import MonacoEditor from "@monaco-editor/react";
 
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
-import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
-import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 
 self.MonacoEnvironment = {
   getWorker(_, label) {
     if (label === "json") {
       return new jsonWorker();
-    }
-    if (label === "css" || label === "scss" || label === "less") {
-      return new cssWorker();
-    }
-    if (label === "html" || label === "handlebars" || label === "razor") {
-      return new htmlWorker();
     }
     if (label === "typescript" || label === "javascript") {
       return new tsWorker();
@@ -26,7 +18,10 @@ self.MonacoEnvironment = {
 };
 
 import { loader } from "@monaco-editor/react";
-import * as monaco from "monaco-editor";
+import "monaco-editor/esm/vs/language/json/monaco.contribution.js";
+import "monaco-editor/esm/vs/language/typescript/monaco.contribution.js";
+import "monaco-editor/esm/vs/basic-languages/python/python.contribution.js";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 loader.config({ monaco });
 

--- a/frontend/src/components/editor.tsx
+++ b/frontend/src/components/editor.tsx
@@ -18,9 +18,10 @@ self.MonacoEnvironment = {
 };
 
 import { loader } from "@monaco-editor/react";
-import "monaco-editor/esm/vs/language/json/monaco.contribution.js";
-import "monaco-editor/esm/vs/language/typescript/monaco.contribution.js";
-import "monaco-editor/esm/vs/basic-languages/python/python.contribution.js";
+import "monaco-editor/esm/vs/language/json/monaco.contribution";
+import "monaco-editor/esm/vs/language/typescript/monaco.contribution";
+import "monaco-editor/esm/vs/basic-languages/python/python.contribution";
+import "monaco-editor/esm/vs/editor/editor.all";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 loader.config({ monaco });

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -10,234 +10,234 @@
 
 // Import Routes
 
-import { Route as rootRoute } from "./routes/__root";
-import { Route as RequestImport } from "./routes/request";
-import { Route as DocsImport } from "./routes/docs";
-import { Route as ConfigImport } from "./routes/config";
-import { Route as SourcesRouteImport } from "./routes/sources/route";
-import { Route as ProvidersRouteImport } from "./routes/providers/route";
-import { Route as ListsRouteImport } from "./routes/lists/route";
-import { Route as HistoryRouteImport } from "./routes/history/route";
-import { Route as IndexImport } from "./routes/index";
-import { Route as SourcesIndexImport } from "./routes/sources/index";
-import { Route as ProvidersIndexImport } from "./routes/providers/index";
-import { Route as ListsIndexImport } from "./routes/lists/index";
-import { Route as HistoryIndexImport } from "./routes/history/index";
-import { Route as SourcesNewImport } from "./routes/sources/new";
-import { Route as SourcesIdImport } from "./routes/sources/$id";
-import { Route as ProvidersNewImport } from "./routes/providers/new";
-import { Route as ProvidersIdImport } from "./routes/providers/$id";
-import { Route as ListsNewImport } from "./routes/lists/new";
-import { Route as ListsIdImport } from "./routes/lists/$id";
-import { Route as HistoryIdImport } from "./routes/history/$id";
-import { Route as SourcesIdEditImport } from "./routes/sources/$id.edit";
-import { Route as ProvidersIdEditImport } from "./routes/providers/$id.edit";
-import { Route as ListsIdEditImport } from "./routes/lists/$id.edit";
+import { Route as rootRoute } from './routes/__root'
+import { Route as RequestImport } from './routes/request'
+import { Route as DocsImport } from './routes/docs'
+import { Route as ConfigImport } from './routes/config'
+import { Route as SourcesRouteImport } from './routes/sources/route'
+import { Route as ProvidersRouteImport } from './routes/providers/route'
+import { Route as ListsRouteImport } from './routes/lists/route'
+import { Route as HistoryRouteImport } from './routes/history/route'
+import { Route as IndexImport } from './routes/index'
+import { Route as SourcesIndexImport } from './routes/sources/index'
+import { Route as ProvidersIndexImport } from './routes/providers/index'
+import { Route as ListsIndexImport } from './routes/lists/index'
+import { Route as HistoryIndexImport } from './routes/history/index'
+import { Route as SourcesNewImport } from './routes/sources/new'
+import { Route as SourcesIdImport } from './routes/sources/$id'
+import { Route as ProvidersNewImport } from './routes/providers/new'
+import { Route as ProvidersIdImport } from './routes/providers/$id'
+import { Route as ListsNewImport } from './routes/lists/new'
+import { Route as ListsIdImport } from './routes/lists/$id'
+import { Route as HistoryIdImport } from './routes/history/$id'
+import { Route as SourcesIdEditImport } from './routes/sources/$id.edit'
+import { Route as ProvidersIdEditImport } from './routes/providers/$id.edit'
+import { Route as ListsIdEditImport } from './routes/lists/$id.edit'
 
 // Create/Update Routes
 
 const RequestRoute = RequestImport.update({
-  path: "/request",
+  path: '/request',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const DocsRoute = DocsImport.update({
-  path: "/docs",
+  path: '/docs',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ConfigRoute = ConfigImport.update({
-  path: "/config",
+  path: '/config',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const SourcesRouteRoute = SourcesRouteImport.update({
-  path: "/sources",
+  path: '/sources',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ProvidersRouteRoute = ProvidersRouteImport.update({
-  path: "/providers",
+  path: '/providers',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const ListsRouteRoute = ListsRouteImport.update({
-  path: "/lists",
+  path: '/lists',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const HistoryRouteRoute = HistoryRouteImport.update({
-  path: "/history",
+  path: '/history',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const IndexRoute = IndexImport.update({
-  path: "/",
+  path: '/',
   getParentRoute: () => rootRoute,
-} as any);
+} as any)
 
 const SourcesIndexRoute = SourcesIndexImport.update({
-  path: "/",
+  path: '/',
   getParentRoute: () => SourcesRouteRoute,
-} as any);
+} as any)
 
 const ProvidersIndexRoute = ProvidersIndexImport.update({
-  path: "/",
+  path: '/',
   getParentRoute: () => ProvidersRouteRoute,
-} as any);
+} as any)
 
 const ListsIndexRoute = ListsIndexImport.update({
-  path: "/",
+  path: '/',
   getParentRoute: () => ListsRouteRoute,
-} as any);
+} as any)
 
 const HistoryIndexRoute = HistoryIndexImport.update({
-  path: "/",
+  path: '/',
   getParentRoute: () => HistoryRouteRoute,
-} as any);
+} as any)
 
 const SourcesNewRoute = SourcesNewImport.update({
-  path: "/new",
+  path: '/new',
   getParentRoute: () => SourcesRouteRoute,
-} as any);
+} as any)
 
 const SourcesIdRoute = SourcesIdImport.update({
-  path: "/$id",
+  path: '/$id',
   getParentRoute: () => SourcesRouteRoute,
-} as any);
+} as any)
 
 const ProvidersNewRoute = ProvidersNewImport.update({
-  path: "/new",
+  path: '/new',
   getParentRoute: () => ProvidersRouteRoute,
-} as any);
+} as any)
 
 const ProvidersIdRoute = ProvidersIdImport.update({
-  path: "/$id",
+  path: '/$id',
   getParentRoute: () => ProvidersRouteRoute,
-} as any);
+} as any)
 
 const ListsNewRoute = ListsNewImport.update({
-  path: "/new",
+  path: '/new',
   getParentRoute: () => ListsRouteRoute,
-} as any);
+} as any)
 
 const ListsIdRoute = ListsIdImport.update({
-  path: "/$id",
+  path: '/$id',
   getParentRoute: () => ListsRouteRoute,
-} as any);
+} as any)
 
 const HistoryIdRoute = HistoryIdImport.update({
-  path: "/$id",
+  path: '/$id',
   getParentRoute: () => HistoryRouteRoute,
-} as any);
+} as any)
 
 const SourcesIdEditRoute = SourcesIdEditImport.update({
-  path: "/edit",
+  path: '/edit',
   getParentRoute: () => SourcesIdRoute,
-} as any);
+} as any)
 
 const ProvidersIdEditRoute = ProvidersIdEditImport.update({
-  path: "/edit",
+  path: '/edit',
   getParentRoute: () => ProvidersIdRoute,
-} as any);
+} as any)
 
 const ListsIdEditRoute = ListsIdEditImport.update({
-  path: "/edit",
+  path: '/edit',
   getParentRoute: () => ListsIdRoute,
-} as any);
+} as any)
 
 // Populate the FileRoutesByPath interface
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/": {
-      preLoaderRoute: typeof IndexImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/history": {
-      preLoaderRoute: typeof HistoryRouteImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/lists": {
-      preLoaderRoute: typeof ListsRouteImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/providers": {
-      preLoaderRoute: typeof ProvidersRouteImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/sources": {
-      preLoaderRoute: typeof SourcesRouteImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/config": {
-      preLoaderRoute: typeof ConfigImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/docs": {
-      preLoaderRoute: typeof DocsImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/request": {
-      preLoaderRoute: typeof RequestImport;
-      parentRoute: typeof rootRoute;
-    };
-    "/history/$id": {
-      preLoaderRoute: typeof HistoryIdImport;
-      parentRoute: typeof HistoryRouteImport;
-    };
-    "/lists/$id": {
-      preLoaderRoute: typeof ListsIdImport;
-      parentRoute: typeof ListsRouteImport;
-    };
-    "/lists/new": {
-      preLoaderRoute: typeof ListsNewImport;
-      parentRoute: typeof ListsRouteImport;
-    };
-    "/providers/$id": {
-      preLoaderRoute: typeof ProvidersIdImport;
-      parentRoute: typeof ProvidersRouteImport;
-    };
-    "/providers/new": {
-      preLoaderRoute: typeof ProvidersNewImport;
-      parentRoute: typeof ProvidersRouteImport;
-    };
-    "/sources/$id": {
-      preLoaderRoute: typeof SourcesIdImport;
-      parentRoute: typeof SourcesRouteImport;
-    };
-    "/sources/new": {
-      preLoaderRoute: typeof SourcesNewImport;
-      parentRoute: typeof SourcesRouteImport;
-    };
-    "/history/": {
-      preLoaderRoute: typeof HistoryIndexImport;
-      parentRoute: typeof HistoryRouteImport;
-    };
-    "/lists/": {
-      preLoaderRoute: typeof ListsIndexImport;
-      parentRoute: typeof ListsRouteImport;
-    };
-    "/providers/": {
-      preLoaderRoute: typeof ProvidersIndexImport;
-      parentRoute: typeof ProvidersRouteImport;
-    };
-    "/sources/": {
-      preLoaderRoute: typeof SourcesIndexImport;
-      parentRoute: typeof SourcesRouteImport;
-    };
-    "/lists/$id/edit": {
-      preLoaderRoute: typeof ListsIdEditImport;
-      parentRoute: typeof ListsIdImport;
-    };
-    "/providers/$id/edit": {
-      preLoaderRoute: typeof ProvidersIdEditImport;
-      parentRoute: typeof ProvidersIdImport;
-    };
-    "/sources/$id/edit": {
-      preLoaderRoute: typeof SourcesIdEditImport;
-      parentRoute: typeof SourcesIdImport;
-    };
+    '/': {
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/history': {
+      preLoaderRoute: typeof HistoryRouteImport
+      parentRoute: typeof rootRoute
+    }
+    '/lists': {
+      preLoaderRoute: typeof ListsRouteImport
+      parentRoute: typeof rootRoute
+    }
+    '/providers': {
+      preLoaderRoute: typeof ProvidersRouteImport
+      parentRoute: typeof rootRoute
+    }
+    '/sources': {
+      preLoaderRoute: typeof SourcesRouteImport
+      parentRoute: typeof rootRoute
+    }
+    '/config': {
+      preLoaderRoute: typeof ConfigImport
+      parentRoute: typeof rootRoute
+    }
+    '/docs': {
+      preLoaderRoute: typeof DocsImport
+      parentRoute: typeof rootRoute
+    }
+    '/request': {
+      preLoaderRoute: typeof RequestImport
+      parentRoute: typeof rootRoute
+    }
+    '/history/$id': {
+      preLoaderRoute: typeof HistoryIdImport
+      parentRoute: typeof HistoryRouteImport
+    }
+    '/lists/$id': {
+      preLoaderRoute: typeof ListsIdImport
+      parentRoute: typeof ListsRouteImport
+    }
+    '/lists/new': {
+      preLoaderRoute: typeof ListsNewImport
+      parentRoute: typeof ListsRouteImport
+    }
+    '/providers/$id': {
+      preLoaderRoute: typeof ProvidersIdImport
+      parentRoute: typeof ProvidersRouteImport
+    }
+    '/providers/new': {
+      preLoaderRoute: typeof ProvidersNewImport
+      parentRoute: typeof ProvidersRouteImport
+    }
+    '/sources/$id': {
+      preLoaderRoute: typeof SourcesIdImport
+      parentRoute: typeof SourcesRouteImport
+    }
+    '/sources/new': {
+      preLoaderRoute: typeof SourcesNewImport
+      parentRoute: typeof SourcesRouteImport
+    }
+    '/history/': {
+      preLoaderRoute: typeof HistoryIndexImport
+      parentRoute: typeof HistoryRouteImport
+    }
+    '/lists/': {
+      preLoaderRoute: typeof ListsIndexImport
+      parentRoute: typeof ListsRouteImport
+    }
+    '/providers/': {
+      preLoaderRoute: typeof ProvidersIndexImport
+      parentRoute: typeof ProvidersRouteImport
+    }
+    '/sources/': {
+      preLoaderRoute: typeof SourcesIndexImport
+      parentRoute: typeof SourcesRouteImport
+    }
+    '/lists/$id/edit': {
+      preLoaderRoute: typeof ListsIdEditImport
+      parentRoute: typeof ListsIdImport
+    }
+    '/providers/$id/edit': {
+      preLoaderRoute: typeof ProvidersIdEditImport
+      parentRoute: typeof ProvidersIdImport
+    }
+    '/sources/$id/edit': {
+      preLoaderRoute: typeof SourcesIdEditImport
+      parentRoute: typeof SourcesIdImport
+    }
   }
 }
 
@@ -264,6 +264,6 @@ export const routeTree = rootRoute.addChildren([
   ConfigRoute,
   DocsRoute,
   RequestRoute,
-]);
+])
 
 /* prettier-ignore-end */

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -10,234 +10,234 @@
 
 // Import Routes
 
-import { Route as rootRoute } from './routes/__root'
-import { Route as RequestImport } from './routes/request'
-import { Route as DocsImport } from './routes/docs'
-import { Route as ConfigImport } from './routes/config'
-import { Route as SourcesRouteImport } from './routes/sources/route'
-import { Route as ProvidersRouteImport } from './routes/providers/route'
-import { Route as ListsRouteImport } from './routes/lists/route'
-import { Route as HistoryRouteImport } from './routes/history/route'
-import { Route as IndexImport } from './routes/index'
-import { Route as SourcesIndexImport } from './routes/sources/index'
-import { Route as ProvidersIndexImport } from './routes/providers/index'
-import { Route as ListsIndexImport } from './routes/lists/index'
-import { Route as HistoryIndexImport } from './routes/history/index'
-import { Route as SourcesNewImport } from './routes/sources/new'
-import { Route as SourcesIdImport } from './routes/sources/$id'
-import { Route as ProvidersNewImport } from './routes/providers/new'
-import { Route as ProvidersIdImport } from './routes/providers/$id'
-import { Route as ListsNewImport } from './routes/lists/new'
-import { Route as ListsIdImport } from './routes/lists/$id'
-import { Route as HistoryIdImport } from './routes/history/$id'
-import { Route as SourcesIdEditImport } from './routes/sources/$id.edit'
-import { Route as ProvidersIdEditImport } from './routes/providers/$id.edit'
-import { Route as ListsIdEditImport } from './routes/lists/$id.edit'
+import { Route as rootRoute } from "./routes/__root";
+import { Route as RequestImport } from "./routes/request";
+import { Route as DocsImport } from "./routes/docs";
+import { Route as ConfigImport } from "./routes/config";
+import { Route as SourcesRouteImport } from "./routes/sources/route";
+import { Route as ProvidersRouteImport } from "./routes/providers/route";
+import { Route as ListsRouteImport } from "./routes/lists/route";
+import { Route as HistoryRouteImport } from "./routes/history/route";
+import { Route as IndexImport } from "./routes/index";
+import { Route as SourcesIndexImport } from "./routes/sources/index";
+import { Route as ProvidersIndexImport } from "./routes/providers/index";
+import { Route as ListsIndexImport } from "./routes/lists/index";
+import { Route as HistoryIndexImport } from "./routes/history/index";
+import { Route as SourcesNewImport } from "./routes/sources/new";
+import { Route as SourcesIdImport } from "./routes/sources/$id";
+import { Route as ProvidersNewImport } from "./routes/providers/new";
+import { Route as ProvidersIdImport } from "./routes/providers/$id";
+import { Route as ListsNewImport } from "./routes/lists/new";
+import { Route as ListsIdImport } from "./routes/lists/$id";
+import { Route as HistoryIdImport } from "./routes/history/$id";
+import { Route as SourcesIdEditImport } from "./routes/sources/$id.edit";
+import { Route as ProvidersIdEditImport } from "./routes/providers/$id.edit";
+import { Route as ListsIdEditImport } from "./routes/lists/$id.edit";
 
 // Create/Update Routes
 
 const RequestRoute = RequestImport.update({
-  path: '/request',
+  path: "/request",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 const DocsRoute = DocsImport.update({
-  path: '/docs',
+  path: "/docs",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 const ConfigRoute = ConfigImport.update({
-  path: '/config',
+  path: "/config",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 const SourcesRouteRoute = SourcesRouteImport.update({
-  path: '/sources',
+  path: "/sources",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 const ProvidersRouteRoute = ProvidersRouteImport.update({
-  path: '/providers',
+  path: "/providers",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 const ListsRouteRoute = ListsRouteImport.update({
-  path: '/lists',
+  path: "/lists",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 const HistoryRouteRoute = HistoryRouteImport.update({
-  path: '/history',
+  path: "/history",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 const IndexRoute = IndexImport.update({
-  path: '/',
+  path: "/",
   getParentRoute: () => rootRoute,
-} as any)
+} as any);
 
 const SourcesIndexRoute = SourcesIndexImport.update({
-  path: '/',
+  path: "/",
   getParentRoute: () => SourcesRouteRoute,
-} as any)
+} as any);
 
 const ProvidersIndexRoute = ProvidersIndexImport.update({
-  path: '/',
+  path: "/",
   getParentRoute: () => ProvidersRouteRoute,
-} as any)
+} as any);
 
 const ListsIndexRoute = ListsIndexImport.update({
-  path: '/',
+  path: "/",
   getParentRoute: () => ListsRouteRoute,
-} as any)
+} as any);
 
 const HistoryIndexRoute = HistoryIndexImport.update({
-  path: '/',
+  path: "/",
   getParentRoute: () => HistoryRouteRoute,
-} as any)
+} as any);
 
 const SourcesNewRoute = SourcesNewImport.update({
-  path: '/new',
+  path: "/new",
   getParentRoute: () => SourcesRouteRoute,
-} as any)
+} as any);
 
 const SourcesIdRoute = SourcesIdImport.update({
-  path: '/$id',
+  path: "/$id",
   getParentRoute: () => SourcesRouteRoute,
-} as any)
+} as any);
 
 const ProvidersNewRoute = ProvidersNewImport.update({
-  path: '/new',
+  path: "/new",
   getParentRoute: () => ProvidersRouteRoute,
-} as any)
+} as any);
 
 const ProvidersIdRoute = ProvidersIdImport.update({
-  path: '/$id',
+  path: "/$id",
   getParentRoute: () => ProvidersRouteRoute,
-} as any)
+} as any);
 
 const ListsNewRoute = ListsNewImport.update({
-  path: '/new',
+  path: "/new",
   getParentRoute: () => ListsRouteRoute,
-} as any)
+} as any);
 
 const ListsIdRoute = ListsIdImport.update({
-  path: '/$id',
+  path: "/$id",
   getParentRoute: () => ListsRouteRoute,
-} as any)
+} as any);
 
 const HistoryIdRoute = HistoryIdImport.update({
-  path: '/$id',
+  path: "/$id",
   getParentRoute: () => HistoryRouteRoute,
-} as any)
+} as any);
 
 const SourcesIdEditRoute = SourcesIdEditImport.update({
-  path: '/edit',
+  path: "/edit",
   getParentRoute: () => SourcesIdRoute,
-} as any)
+} as any);
 
 const ProvidersIdEditRoute = ProvidersIdEditImport.update({
-  path: '/edit',
+  path: "/edit",
   getParentRoute: () => ProvidersIdRoute,
-} as any)
+} as any);
 
 const ListsIdEditRoute = ListsIdEditImport.update({
-  path: '/edit',
+  path: "/edit",
   getParentRoute: () => ListsIdRoute,
-} as any)
+} as any);
 
 // Populate the FileRoutesByPath interface
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/': {
-      preLoaderRoute: typeof IndexImport
-      parentRoute: typeof rootRoute
-    }
-    '/history': {
-      preLoaderRoute: typeof HistoryRouteImport
-      parentRoute: typeof rootRoute
-    }
-    '/lists': {
-      preLoaderRoute: typeof ListsRouteImport
-      parentRoute: typeof rootRoute
-    }
-    '/providers': {
-      preLoaderRoute: typeof ProvidersRouteImport
-      parentRoute: typeof rootRoute
-    }
-    '/sources': {
-      preLoaderRoute: typeof SourcesRouteImport
-      parentRoute: typeof rootRoute
-    }
-    '/config': {
-      preLoaderRoute: typeof ConfigImport
-      parentRoute: typeof rootRoute
-    }
-    '/docs': {
-      preLoaderRoute: typeof DocsImport
-      parentRoute: typeof rootRoute
-    }
-    '/request': {
-      preLoaderRoute: typeof RequestImport
-      parentRoute: typeof rootRoute
-    }
-    '/history/$id': {
-      preLoaderRoute: typeof HistoryIdImport
-      parentRoute: typeof HistoryRouteImport
-    }
-    '/lists/$id': {
-      preLoaderRoute: typeof ListsIdImport
-      parentRoute: typeof ListsRouteImport
-    }
-    '/lists/new': {
-      preLoaderRoute: typeof ListsNewImport
-      parentRoute: typeof ListsRouteImport
-    }
-    '/providers/$id': {
-      preLoaderRoute: typeof ProvidersIdImport
-      parentRoute: typeof ProvidersRouteImport
-    }
-    '/providers/new': {
-      preLoaderRoute: typeof ProvidersNewImport
-      parentRoute: typeof ProvidersRouteImport
-    }
-    '/sources/$id': {
-      preLoaderRoute: typeof SourcesIdImport
-      parentRoute: typeof SourcesRouteImport
-    }
-    '/sources/new': {
-      preLoaderRoute: typeof SourcesNewImport
-      parentRoute: typeof SourcesRouteImport
-    }
-    '/history/': {
-      preLoaderRoute: typeof HistoryIndexImport
-      parentRoute: typeof HistoryRouteImport
-    }
-    '/lists/': {
-      preLoaderRoute: typeof ListsIndexImport
-      parentRoute: typeof ListsRouteImport
-    }
-    '/providers/': {
-      preLoaderRoute: typeof ProvidersIndexImport
-      parentRoute: typeof ProvidersRouteImport
-    }
-    '/sources/': {
-      preLoaderRoute: typeof SourcesIndexImport
-      parentRoute: typeof SourcesRouteImport
-    }
-    '/lists/$id/edit': {
-      preLoaderRoute: typeof ListsIdEditImport
-      parentRoute: typeof ListsIdImport
-    }
-    '/providers/$id/edit': {
-      preLoaderRoute: typeof ProvidersIdEditImport
-      parentRoute: typeof ProvidersIdImport
-    }
-    '/sources/$id/edit': {
-      preLoaderRoute: typeof SourcesIdEditImport
-      parentRoute: typeof SourcesIdImport
-    }
+    "/": {
+      preLoaderRoute: typeof IndexImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/history": {
+      preLoaderRoute: typeof HistoryRouteImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/lists": {
+      preLoaderRoute: typeof ListsRouteImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/providers": {
+      preLoaderRoute: typeof ProvidersRouteImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/sources": {
+      preLoaderRoute: typeof SourcesRouteImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/config": {
+      preLoaderRoute: typeof ConfigImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/docs": {
+      preLoaderRoute: typeof DocsImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/request": {
+      preLoaderRoute: typeof RequestImport;
+      parentRoute: typeof rootRoute;
+    };
+    "/history/$id": {
+      preLoaderRoute: typeof HistoryIdImport;
+      parentRoute: typeof HistoryRouteImport;
+    };
+    "/lists/$id": {
+      preLoaderRoute: typeof ListsIdImport;
+      parentRoute: typeof ListsRouteImport;
+    };
+    "/lists/new": {
+      preLoaderRoute: typeof ListsNewImport;
+      parentRoute: typeof ListsRouteImport;
+    };
+    "/providers/$id": {
+      preLoaderRoute: typeof ProvidersIdImport;
+      parentRoute: typeof ProvidersRouteImport;
+    };
+    "/providers/new": {
+      preLoaderRoute: typeof ProvidersNewImport;
+      parentRoute: typeof ProvidersRouteImport;
+    };
+    "/sources/$id": {
+      preLoaderRoute: typeof SourcesIdImport;
+      parentRoute: typeof SourcesRouteImport;
+    };
+    "/sources/new": {
+      preLoaderRoute: typeof SourcesNewImport;
+      parentRoute: typeof SourcesRouteImport;
+    };
+    "/history/": {
+      preLoaderRoute: typeof HistoryIndexImport;
+      parentRoute: typeof HistoryRouteImport;
+    };
+    "/lists/": {
+      preLoaderRoute: typeof ListsIndexImport;
+      parentRoute: typeof ListsRouteImport;
+    };
+    "/providers/": {
+      preLoaderRoute: typeof ProvidersIndexImport;
+      parentRoute: typeof ProvidersRouteImport;
+    };
+    "/sources/": {
+      preLoaderRoute: typeof SourcesIndexImport;
+      parentRoute: typeof SourcesRouteImport;
+    };
+    "/lists/$id/edit": {
+      preLoaderRoute: typeof ListsIdEditImport;
+      parentRoute: typeof ListsIdImport;
+    };
+    "/providers/$id/edit": {
+      preLoaderRoute: typeof ProvidersIdEditImport;
+      parentRoute: typeof ProvidersIdImport;
+    };
+    "/sources/$id/edit": {
+      preLoaderRoute: typeof SourcesIdEditImport;
+      parentRoute: typeof SourcesIdImport;
+    };
   }
 }
 
@@ -264,6 +264,6 @@ export const routeTree = rootRoute.addChildren([
   ConfigRoute,
   DocsRoute,
   RequestRoute,
-])
+]);
 
 /* prettier-ignore-end */


### PR DESCRIPTION
### Changes

<!-- Specify your changes in bullet points -->

* Specify to only use JSON, TypeScript/JavaScript, Python
* Reduces bundle size and 428 less modules transformed
* Didn't add a language server, but this is not needed

<details>
<summary>Before (Total 10,838.73 KB)</summary>

```
vite v5.2.8 building for production...
✓ 4557 modules transformed.
dist/index.html                                          0.52 kB │ gzip:     0.33 kB
dist/assets/surfing-two-color-6c783-Cz_Ir4Pa.svg         4.85 kB │ gzip:     2.16 kB
dist/assets/day-dreaming-two-color-C5di6o3L.svg          5.26 kB │ gzip:     2.15 kB
dist/assets/hiking-two-color-e83a0-BmTOPHsm.svg          5.80 kB │ gzip:     2.15 kB
dist/assets/files-and-folder-two-color-DumRomKp.svg      6.61 kB │ gzip:     2.18 kB
dist/assets/codicon-BA2IlpFX.ttf                        79.57 kB
dist/assets/editor.worker-BVwmgLrR.js                  210.18 kB
dist/assets/json.worker-BwvX8PuZ.js                    338.96 kB
dist/assets/ts.worker-CwG1rUES.js                    4,847.56 kB
dist/assets/index-FRj8asY6.css                         170.42 kB │ gzip:    27.95 kB
dist/assets/azcli-CElzELwZ.js                            1.09 kB │ gzip:     0.46 kB
dist/assets/javascript-Ckn89QAV.js                       1.19 kB │ gzip:     0.63 kB
dist/assets/ini-8kKHd4ZL.js                              1.35 kB │ gzip:     0.68 kB
dist/assets/csp-DgZoLDI1.js                              1.67 kB │ gzip:     0.66 kB
dist/assets/pla-DrIuu9u1.js                              1.93 kB │ gzip:     0.79 kB
dist/assets/scheme-55eqh71t.js                           2.01 kB │ gzip:     0.97 kB
dist/assets/flow9-Bi_qi707.js                            2.06 kB │ gzip:     1.00 kB
dist/assets/sb-C6Gjjw_x.js                               2.08 kB │ gzip:     0.97 kB
dist/assets/bat-CUsyEhik.js                              2.09 kB │ gzip:     1.01 kB
dist/assets/dockerfile-CuCtxA7T.js                       2.12 kB │ gzip:     0.82 kB
dist/assets/pascaligo-BACCcnx_.js                        2.25 kB │ gzip:     1.05 kB
dist/assets/lua-Crkvc3mc.js                              2.37 kB │ gzip:     1.07 kB
dist/assets/cameligo-ClBCoF8h.js                         2.43 kB │ gzip:     1.11 kB
dist/assets/graphql-D5sGVkLV.js                          2.51 kB │ gzip:     1.17 kB
dist/assets/objective-c-BHUZy23s.js                      2.65 kB │ gzip:     1.20 kB
dist/assets/lexon-Bg9QKxBu.js                            2.68 kB │ gzip:     1.07 kB
dist/assets/xml-Bw7L8dSd.js                              2.68 kB │ gzip:     1.11 kB
dist/assets/bicep-BtxyJn6H.js                            2.78 kB │ gzip:     1.11 kB
dist/assets/sparql-LA0C7mUc.js                           2.80 kB │ gzip:     1.31 kB
dist/assets/mips-BE8RsGBA.js                             2.83 kB │ gzip:     1.22 kB
dist/assets/go-DUImKuGY.js                               2.90 kB │ gzip:     1.29 kB
dist/assets/sophia-D6taVZFb.js                           3.01 kB │ gzip:     1.36 kB
dist/assets/m3-DsrzVyM1.js                               3.06 kB │ gzip:     1.47 kB
dist/assets/qsharp-B7F3HtPF.js                           3.18 kB │ gzip:     1.51 kB
dist/assets/fsharp-CxaaEKKi.js                           3.23 kB │ gzip:     1.47 kB
dist/assets/pascal-BemVzBTY.js                           3.24 kB │ gzip:     1.55 kB
dist/assets/shell-DSpi8_qN.js                            3.32 kB │ gzip:     1.35 kB
dist/assets/r-3aLoi2fs.js                                3.38 kB │ gzip:     1.42 kB
dist/assets/java-De1axCfe.js                             3.47 kB │ gzip:     1.55 kB
dist/assets/powershell-Dsa4rhA_.js                       3.52 kB │ gzip:     1.53 kB
dist/assets/cypher-CYoSlgTu.js                           3.63 kB │ gzip:     1.58 kB
dist/assets/kotlin-GbSrCElU.js                           3.69 kB │ gzip:     1.63 kB
dist/assets/redis-jqFeRM5s.js                            3.80 kB │ gzip:     1.64 kB
dist/assets/tcl-DVJXmIwd.js                              3.82 kB │ gzip:     1.52 kB
dist/assets/coffee-DYsfeylR.js                           3.84 kB │ gzip:     1.45 kB
dist/assets/hcl-zD_CCkZ1.js                              3.84 kB │ gzip:     1.64 kB
dist/assets/python-BP3VemWG.js                           3.90 kB │ gzip:     1.74 kB
dist/assets/markdown-CY5IOZuu.js                         4.03 kB │ gzip:     1.54 kB
dist/assets/restructuredtext-hbBFZ0w9.js                 4.14 kB │ gzip:     1.52 kB
dist/assets/less-DNUaDNdz.js                             4.14 kB │ gzip:     1.57 kB
dist/assets/apex-BrXDlLUW.js                             4.20 kB │ gzip:     1.91 kB
dist/assets/liquid-DSXsGcLo.js                           4.24 kB │ gzip:     1.81 kB
dist/assets/yaml-DI25JrSD.js                             4.29 kB │ gzip:     1.67 kB
dist/assets/rust-DIEZMp5R.js                             4.41 kB │ gzip:     1.97 kB
dist/assets/dart-BGDl7St1.js                             4.50 kB │ gzip:     1.80 kB
dist/assets/css-KqQ96-gC.js                              4.76 kB │ gzip:     1.53 kB
dist/assets/csharp-Z6z2stHy.js                           4.77 kB │ gzip:     1.88 kB
dist/assets/pug-D2p3uOX2.js                              5.07 kB │ gzip:     1.80 kB
dist/assets/mdx-BqdnuxG5.js                              5.13 kB │ gzip:     1.60 kB
dist/assets/msdax-N5ajIiFQ.js                            5.16 kB │ gzip:     2.11 kB
dist/assets/html-DoNPfzzY.js                             5.29 kB │ gzip:     1.55 kB
dist/assets/swift-DNI1vH3h.js                            5.42 kB │ gzip:     2.22 kB
dist/assets/ecl-BCTFAUpS.js                              5.59 kB │ gzip:     2.38 kB
dist/assets/cpp-VVGvvgir.js                              5.68 kB │ gzip:     2.28 kB
dist/assets/typescript-DUCWgaiK.js                       5.68 kB │ gzip:     2.32 kB
dist/assets/vb-Btz91-7U.js                               6.04 kB │ gzip:     2.21 kB
dist/assets/twig-BVWDLtw5.js                             6.22 kB │ gzip:     1.68 kB
dist/assets/scss-D-OVkc4F.js                             6.66 kB │ gzip:     1.90 kB
dist/assets/handlebars-CH41jPEq.js                       7.05 kB │ gzip:     1.77 kB
dist/assets/julia-D3ApGBxz.js                            7.34 kB │ gzip:     2.81 kB
dist/assets/scala-DZNw3jJB.js                            7.56 kB │ gzip:     2.25 kB
dist/assets/wgsl-D8V_buCG.js                             7.59 kB │ gzip:     2.90 kB
dist/assets/st-C4g7059C.js                               7.64 kB │ gzip:     2.39 kB
dist/assets/systemverilog-DL_FVbcQ.js                    7.85 kB │ gzip:     2.91 kB
dist/assets/postiats-BR_hrfni.js                         8.10 kB │ gzip:     2.59 kB
dist/assets/php-BvyzZa65.js                              8.27 kB │ gzip:     2.22 kB
dist/assets/perl-CuU66Ptk.js                             8.50 kB │ gzip:     3.29 kB
dist/assets/ruby-ByThyB2Q.js                             8.75 kB │ gzip:     2.73 kB
dist/assets/razor-D81b0jsq.js                            9.05 kB │ gzip:     2.45 kB
dist/assets/protobuf-CGsvhooB.js                         9.29 kB │ gzip:     2.23 kB
dist/assets/clojure-B9TqLHAk.js                          9.89 kB │ gzip:     3.77 kB
dist/assets/elixir-C7hRTYZ9.js                          10.50 kB │ gzip:     2.69 kB
dist/assets/sql-C3-3IcFM.js                             10.54 kB │ gzip:     4.01 kB
dist/assets/mysql-DRxbB97D.js                           11.52 kB │ gzip:     4.22 kB
dist/assets/redshift-BriwQgXR.js                        12.05 kB │ gzip:     4.49 kB
dist/assets/pgsql-CQ6TMH2r.js                           13.71 kB │ gzip:     4.65 kB
dist/assets/abap-D8nrxEjS.js                            14.41 kB │ gzip:     5.46 kB
dist/assets/freemarker2-BEIPhvqF.js                     16.37 kB │ gzip:     4.31 kB
dist/assets/powerquery-CKDUeRmd.js                      17.19 kB │ gzip:     5.01 kB
dist/assets/solidity-BHddiNFS.js                        18.84 kB │ gzip:     4.62 kB
dist/assets/tsMode-WUTO1rNA.js                          22.53 kB │ gzip:     6.48 kB
dist/assets/cssMode-BKhPgFU7.js                         33.61 kB │ gzip:     8.92 kB
dist/assets/htmlMode-BANEPIyQ.js                        34.16 kB │ gzip:     9.04 kB
dist/assets/jsonMode-DqGGoLft.js                        39.68 kB │ gzip:    11.14 kB
dist/assets/index-FIVweP2z.js                        4,599.19 kB │ gzip: 1,239.56 kB
```

</details>

<details>
<summary>After (Total 9,233.47 KB)</summary>

```
vite v5.2.8 building for production...
✓ 4129 modules transformed.
dist/index.html                                          0.52 kB │ gzip:   0.33 kB
dist/assets/surfing-two-color-6c783-Cz_Ir4Pa.svg         4.85 kB │ gzip:   2.16 kB
dist/assets/day-dreaming-two-color-C5di6o3L.svg          5.26 kB │ gzip:   2.15 kB
dist/assets/hiking-two-color-e83a0-BmTOPHsm.svg          5.80 kB │ gzip:   2.15 kB
dist/assets/files-and-folder-two-color-DumRomKp.svg      6.61 kB │ gzip:   2.18 kB
dist/assets/editor.worker-BVwmgLrR.js                  210.18 kB
dist/assets/json.worker-BwvX8PuZ.js                    338.96 kB
dist/assets/ts.worker-CwG1rUES.js                    4,847.56 kB
dist/assets/index-C8tNdtyN.css                         109.58 kB │ gzip:  18.50 kB
dist/assets/python-CAyKeWz6.js                           3.90 kB │ gzip:   1.74 kB
dist/assets/tsMode-DmLZmlxe.js                          22.53 kB │ gzip:   6.48 kB
dist/assets/jsonMode-XmqCjqLz.js                        39.68 kB │ gzip:  11.14 kB
dist/assets/index-DL-ssF1T.js                        3,638.04 kB │ gzip: 997.28 kB
```

</details>

### Linked Issues

<!-- Specify the linked GitHub issue, every change should have a linked issue, whether it fixes/closes it or not -->

closes #10 