### PR TITLE
fix: make family and given names optional in frontend and use name for sidenav

### DIFF
--- a/frontend/src/atoms/auth.ts
+++ b/frontend/src/atoms/auth.ts
@@ -4,8 +4,8 @@ interface User {
   id: string;
   email: string;
   name: string;
-  givenName: string;
-  familyName: string;
+  givenName?: string;
+  familyName?: string;
   roles: string[];
   token: string;
 }

--- a/frontend/src/components/layouts/authenticated.tsx
+++ b/frontend/src/components/layouts/authenticated.tsx
@@ -257,9 +257,7 @@ export const Layout: React.FC = () => {
           >
             <Avatar className="border">
               <AvatarImage alt="@shadcn" />
-              <AvatarFallback>
-                {auth!.givenName[0] + auth!.familyName[0]}
-              </AvatarFallback>
+              <AvatarFallback>{auth?.name}</AvatarFallback>
             </Avatar>
             <div className={cn("flex flex-col", isCollapsed && "hidden")}>
               <span className="block whitespace-nowrap font-semibold">

--- a/frontend/src/routes/auth/index.tsx
+++ b/frontend/src/routes/auth/index.tsx
@@ -29,8 +29,8 @@ const SaveUserData: React.FC = () => {
           setUser({
             token,
             name: claims.name,
-            givenName: claims.given_name,
-            familyName: claims.family_name,
+            givenName: claims?.given_name,
+            familyName: claims?.family_name,
             email: claims.email,
             id: claims.sub,
             roles: claims.roles,


### PR DESCRIPTION
### Changes

<!-- Specify your changes in bullet points -->
Had forgotten to update this as well when making the change for signup only needing name and not both parts

* make family and given names optional in JWT parsing in frontend
* use `name` and not the two name parts as the user name in the sidenav

### Linked Issues

<!-- Specify the linked GitHub issue, every change should have a linked issue, whether it fixes/closes it or not -->

#55 